### PR TITLE
Fix package

### DIFF
--- a/dionysos-files-mode.el
+++ b/dionysos-files-mode.el
@@ -23,7 +23,7 @@
 
 (require 'cl-lib)
 (require 'f)
-
+(require 's)
 
 (require 'dionysos-backend)
 (require 'dionysos-mode)
@@ -39,7 +39,7 @@
              filename (type-of filename) dionysos-backend)
     (if dionysos-backend
         (funcall (dionysos--backend-start dionysos-backend)
-                 (string-trim filename)
+                 (s-trim filename)
                  'next-action)
       (message "Dionysos: no backend specify."))))
 

--- a/dionysos.el
+++ b/dionysos.el
@@ -5,7 +5,7 @@
 ;; Version: 0.4.0
 ;; Keywords: music
 
-;; Package-Requires: ((libmpdee "2.1.0") (alert "1.2") (s "1.9.0") (dash "2.9.0") (pkg-info "0.5.0"))
+;; Package-Requires: ((libmpdee "2.1.0") (alert "1.2") (s "1.9.0") (dash "2.9.0") (pkg-info "0.5.0") (cl-lib "0.5"))
 
 ;; Copyright (C) 2015 Nicolas Lamirault <nicolas.lamirault@gmail.com>
 
@@ -43,7 +43,7 @@
 
 ;; Customization
 
-(require 'cl)
+(require 'cl-lib)
 
 (require 'dionysos-custom)
 (require 'dionysos-version)


### PR DESCRIPTION
- Use cl-lib.el instead of cl.el. This package used both cl-lib.el and cl.el. it is better to use only cl-lib.el
- Use s-trim instead of string-trim. string-trim was introduced at Emacs 24.4(and it is necessary to load subr-x.el for using it)
